### PR TITLE
error handling: properly detect and raise various kinds of errors

### DIFF
--- a/src/Curl/Multi.jl
+++ b/src/Curl/Multi.jl
@@ -76,9 +76,12 @@ function timer_callback(
 )::Cint
     multi = unsafe_pointer_to_objref(multi_p)::Multi
     @assert handle_p == multi.handle
-    if timeout_ms ≥ 0
+    if timeout_ms == 0
+        @check curl_multi_socket_action(multi.handle, CURL_SOCKET_TIMEOUT, 0)
+        check_multi_info(multi)
+    elseif timeout_ms > 0
         timeout_cb = @cfunction(timeout_callback, Cvoid, (Ptr{Cvoid},))
-        uv_timer_start(multi.timer, timeout_cb, max(1, timeout_ms), 0)
+        uv_timer_start(multi.timer, timeout_cb, timeout_ms, 0)
     else
         uv_timer_stop(multi.timer)
     end

--- a/src/Curl/Multi.jl
+++ b/src/Curl/Multi.jl
@@ -34,6 +34,7 @@ function check_multi_info(multi::Multi)
             @check curl_easy_getinfo(easy_handle, CURLINFO_PRIVATE, easy_p_ref)
             easy = unsafe_pointer_to_objref(easy_p_ref[])::Easy
             @assert easy_handle == easy.handle
+            easy.code = message.code
             close(easy.progress)
             close(easy.buffers)
         else

--- a/src/Download.jl
+++ b/src/Download.jl
@@ -41,8 +41,12 @@ function download(
     remove_handle(downloader.multi, easy)
     status = get_response_code(easy)
     status == 200 && return io
-    response, _ = get_response_headers(easy)
-    error("download failed: $response")
+    if easy.code == Curl.CURLE_OK
+        message = get_response_headers(easy)[1]
+    else
+        message = GC.@preserve easy unsafe_string(pointer(easy.errbuf))
+    end
+    error(message)
 end
 
 function download(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -70,8 +70,8 @@ include("setup.jl")
         @test header(headers′, "Referer") == url
     end
 
-    @testset "get API" begin
-        @testset "basic get usage" begin
+    @testset "request API" begin
+        @testset "basic request usage" begin
             for status in (200, 300, 400)
                 url = "$server/status/$status"
                 resp = request_body(multi, url)[1]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,6 +47,20 @@ include("setup.jl")
         end
     end
 
+    @testset "errors" begin
+        err = @exception Download.download("xyz://invalid")
+        @test err isa ErrorException
+        @test startswith(err.msg, "Protocol \"xyz\" not supported")
+
+        err = @exception Download.download("https://invalid")
+        @test err isa ErrorException
+        @test startswith(err.msg, "Could not resolve host")
+
+        err = @exception Download.download("$server/status/404")
+        @test err isa ErrorException
+        @test contains(err.msg, r"^HTTP/\d+(?:\.\d+)?\s+404\b")
+    end
+
     @testset "concurrent requests" begin
         count = 10
         delay = 2

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -4,6 +4,10 @@ using Download.Curl
 
 include("json.jl")
 
+if VERSION < v"1.5"
+    contains(haystack, needle) = occursin(needle, haystack)
+end
+
 function download_body(url::AbstractString, headers = Union{}[])
     sprint() do io
         Download.download(url, io, headers = headers)
@@ -43,6 +47,15 @@ function test_response_string(response::AbstractString, status::Integer)
     m = match(r"^HTTP/\d+(?:\.\d+)?\s+(\d+)\b", response)
     @test m !== nothing
     @test parse(Int, m.captures[1]) == status
+end
+
+macro exception(ex)
+    quote
+        try $(esc(ex))
+        catch err
+            err
+        end
+    end
 end
 
 # URL escape & unescape


### PR DESCRIPTION
This includes real errors like using an unsupported protocol or making a
request to a server whose name cannot be resolved, but for `download` it
also includes HTTP-level errors like 404s, etc.

This requires fixing a bug inherited from some laziness in the example
code provided by libcurl, upon which this code was originally based.